### PR TITLE
Add "ultratypes" and sync more names with decomp

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -3,33 +3,10 @@
 
 #include <stdint.h>
 
+#include "os.h"
+#include "types.h"
 #include "version.h"
 
-// os.h
-#define OS_CACHED_REGION_PREFIX 0x8000
-#define OS_BASE_CACHED          (OS_CACHED_REGION_PREFIX << 16)
-
-// OSAddress.h
-static inline void* OSPhysicalToCached(uint32_t ofs) {
-    return (void*)(ofs + OS_BASE_CACHED);
-}
-
-inline uint64_t gettick() {
-    register uint32_t tbu;
-    register uint32_t tbl;
-
-    // clang-format off
-    __asm__ __volatile__(
-        "mftbl %0\n"
-        "mftbu %1\n"
-        ::
-        "r"(tbl), "r"(tbu));
-    // clang-format on
-
-    return (uint64_t)((uint64_t)tbu << 32 | tbl);
-}
-
-// cpu.h
 #if VC_VERSION == NACE
 #define DEVICE_ADDRESS_INDEX_BITS 20
 #else
@@ -43,23 +20,23 @@ typedef int (*UnknownBlockCallback)(CpuBlock* pBlock, int bUnknown);
 
 struct CpuBlock {
     /* 0x00 */ struct CpuBlock* pNext;
-    /* 0x04 */ uint32_t nSize;
+    /* 0x04 */ u32 nSize;
     /* 0x08 */ UnknownBlockCallback pfUnknown;
-    /* 0x0C */ uint32_t nAddress0;
-    /* 0x10 */ uint32_t nAddress1;
+    /* 0x0C */ u32 nAddress0;
+    /* 0x10 */ u32 nAddress1;
 }; // size = 0x14
 
 typedef int (*GetBlockFunc)(void* pObject, CpuBlock* pBlock);
 
-typedef int (*Put8Func)(void* pObject, uint32_t nAddress, int8_t* pData);
-typedef int (*Put16Func)(void* pObject, uint32_t nAddress, int16_t* pData);
-typedef int (*Put32Func)(void* pObject, uint32_t nAddress, int32_t* pData);
-typedef int (*Put64Func)(void* pObject, uint32_t nAddress, int64_t* pData);
+typedef int (*Put8Func)(void* pObject, u32 nAddress, s8* pData);
+typedef int (*Put16Func)(void* pObject, u32 nAddress, s16* pData);
+typedef int (*Put32Func)(void* pObject, u32 nAddress, s32* pData);
+typedef int (*Put64Func)(void* pObject, u32 nAddress, s64* pData);
 
-typedef int (*Get8Func)(void* pObject, uint32_t nAddress, int8_t* pData);
-typedef int (*Get16Func)(void* pObject, uint32_t nAddress, int16_t* pData);
-typedef int (*Get32Func)(void* pObject, uint32_t nAddress, int32_t* pData);
-typedef int (*Get64Func)(void* pObject, uint32_t nAddress, int64_t* pData);
+typedef int (*Get8Func)(void* pObject, u32 nAddress, s8* pData);
+typedef int (*Get16Func)(void* pObject, u32 nAddress, s16* pData);
+typedef int (*Get32Func)(void* pObject, u32 nAddress, s32* pData);
+typedef int (*Get64Func)(void* pObject, u32 nAddress, s64* pData);
 
 typedef enum CpuExceptionCode {
     CEC_NONE = -1,
@@ -113,81 +90,81 @@ typedef enum CpuSize {
 
 typedef union CpuGpr {
     struct {
-        /* 0x0 */ int8_t _0s8;
-        /* 0x1 */ int8_t _1s8;
-        /* 0x2 */ int8_t _2s8;
-        /* 0x3 */ int8_t _3s8;
-        /* 0x4 */ int8_t _4s8;
-        /* 0x5 */ int8_t _5s8;
-        /* 0x6 */ int8_t _6s8;
-        /* 0x7 */ int8_t int8_t;
+        /* 0x0 */ s8 _0s8;
+        /* 0x1 */ s8 _1s8;
+        /* 0x2 */ s8 _2s8;
+        /* 0x3 */ s8 _3s8;
+        /* 0x4 */ s8 _4s8;
+        /* 0x5 */ s8 _5s8;
+        /* 0x6 */ s8 _6s8;
+        /* 0x7 */ s8 s8;
     };
     struct {
-        /* 0x0 */ int16_t _0s16;
-        /* 0x2 */ int16_t _1s16;
-        /* 0x4 */ int16_t _2s16;
-        /* 0x6 */ int16_t int16_t;
+        /* 0x0 */ s16 _0s16;
+        /* 0x2 */ s16 _1s16;
+        /* 0x4 */ s16 _2s16;
+        /* 0x6 */ s16 s16;
     };
     struct {
-        /* 0x0 */ int32_t _0s32;
-        /* 0x4 */ int32_t int32_t;
+        /* 0x0 */ s32 _0s32;
+        /* 0x4 */ s32 s32;
     };
     struct {
-        /* 0x0 */ int64_t int64_t;
+        /* 0x0 */ s64 s64;
     };
     struct {
-        /* 0x0 */ uint8_t _0u8;
-        /* 0x1 */ uint8_t _1u8;
-        /* 0x2 */ uint8_t _2u8;
-        /* 0x3 */ uint8_t _3u8;
-        /* 0x4 */ uint8_t _4u8;
-        /* 0x5 */ uint8_t _5u8;
-        /* 0x6 */ uint8_t _6u8;
-        /* 0x7 */ uint8_t uint8_t;
+        /* 0x0 */ u8 _0u8;
+        /* 0x1 */ u8 _1u8;
+        /* 0x2 */ u8 _2u8;
+        /* 0x3 */ u8 _3u8;
+        /* 0x4 */ u8 _4u8;
+        /* 0x5 */ u8 _5u8;
+        /* 0x6 */ u8 _6u8;
+        /* 0x7 */ u8 u8;
     };
     struct {
-        /* 0x0 */ uint16_t _0u16;
-        /* 0x2 */ uint16_t _1u16;
-        /* 0x4 */ uint16_t _2u16;
-        /* 0x6 */ uint16_t uint16_t;
+        /* 0x0 */ u16 _0u16;
+        /* 0x2 */ u16 _1u16;
+        /* 0x4 */ u16 _2u16;
+        /* 0x6 */ u16 u16;
     };
     struct {
-        /* 0x0 */ uint32_t _0u32;
-        /* 0x4 */ uint32_t uint32_t;
+        /* 0x0 */ u32 _0u32;
+        /* 0x4 */ u32 u32;
     };
     struct {
-        /* 0x0 */ uint64_t uint64_t;
+        /* 0x0 */ u64 u64;
     };
 } CpuGpr;
 
 typedef union CpuFpr {
     struct {
-        /* 0x0 */ float _0f32;
-        /* 0x4 */ float f32;
+        /* 0x0 */ f32 _0f32;
+        /* 0x4 */ f32 f32;
     };
     struct {
-        /* 0x0 */ double f64;
+        /* 0x0 */ f64 f64;
     };
     struct {
-        /* 0x0 */ int32_t _0s32;
-        /* 0x4 */ int32_t int32_t;
+        /* 0x0 */ s32 _0s32;
+        /* 0x4 */ s32 s32;
     };
     struct {
-        /* 0x0 */ int64_t int64_t;
+        /* 0x0 */ s64 s64;
     };
     struct {
-        /* 0x0 */ uint32_t _0u32;
-        /* 0x4 */ uint32_t uint32_t;
+        /* 0x0 */ u32 _0u32;
+        /* 0x4 */ u32 u32;
     };
     struct {
-        /* 0x0 */ uint64_t uint64_t;
+        /* 0x0 */ u64 u64;
     };
 } CpuFpr;
 
 typedef struct CpuDevice {
-    /* 0x00 */ int32_t nType;
+    /* 0x00 */ s32 nType;
     /* 0x04 */ void* pObject;
-    /* 0x08 */ int32_t nOffsetAddress;
+    /* 0x08 */ s32 nOffsetAddress;
     /* 0x0C */ Get8Func pfGet8;
     /* 0x10 */ Get16Func pfGet16;
     /* 0x14 */ Get32Func pfGet32;
@@ -198,122 +175,118 @@ typedef struct CpuDevice {
     /* 0x28 */ Put64Func pfPut64;
 #if IS_OOT
     /* 0x2C */ GetBlockFunc pfGetBlock;
-    /* 0x30 */ uint32_t nAddressVirtual0;
-    /* 0x34 */ uint32_t nAddressVirtual1;
-    /* 0x38 */ uint32_t nAddressPhysical0;
-    /* 0x3C */ uint32_t nAddressPhysical1;
+    /* 0x30 */ u32 nAddressVirtual0;
+    /* 0x34 */ u32 nAddressVirtual1;
+    /* 0x38 */ u32 nAddressPhysical0;
+    /* 0x3C */ u32 nAddressPhysical1;
 #elif IS_MM
-    /* 0x2C */ uint32_t nAddressPhysical;
-    /* 0x30 */ uint32_t nSize;
+    /* 0x2C */ u32 nAddressPhysical;
+    /* 0x30 */ u32 nSize;
 #endif
 } CpuDevice; // size = 0x40
 
 typedef struct CpuJump {
-    /* 0x0 */ int32_t nOffsetHost;
-    /* 0x4 */ int32_t nAddressN64;
+    /* 0x0 */ s32 nOffsetHost;
+    /* 0x4 */ s32 nAddressN64;
 } CpuJump; // size = 0x8
 
-// cpu_callerID
 typedef struct CpuCallerID {
-    /* 0x0 */ int32_t N64address;
-    /* 0x4 */ int32_t GCNaddress;
+    /* 0x0 */ s32 N64address;
+    /* 0x4 */ s32 GCNaddress;
 } CpuCallerID; // size = 0x8
 
 typedef struct CpuFunction CpuFunction;
 
-// cpu_function
 struct CpuFunction {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
-    /* 0x08 */ int32_t nCountJump;
+    /* 0x08 */ s32 nCountJump;
     /* 0x0C */ CpuJump* aJump;
-    /* 0x10 */ int32_t nAddress0;
-    /* 0x14 */ int32_t nAddress1;
+    /* 0x10 */ s32 nAddress0;
+    /* 0x14 */ s32 nAddress1;
     /* 0x18 */ CpuCallerID* block;
-    /* 0x1C */ int32_t callerID_total;
-    /* 0x20 */ int32_t callerID_flag;
-    /* 0x24 */ uint32_t nChecksum;
-    /* 0x28 */ int32_t timeToLive;
-    /* 0x2C */ int32_t memory_size;
-    /* 0x30 */ int32_t heapID;
-    /* 0x34 */ int32_t heapWhere;
-    /* 0x38 */ int32_t treeheapWhere;
+    /* 0x1C */ s32 callerID_total;
+    /* 0x20 */ s32 callerID_flag;
+    /* 0x24 */ u32 nChecksum;
+    /* 0x28 */ s32 timeToLive;
+    /* 0x2C */ s32 memory_size;
+    /* 0x30 */ s32 heapID;
+    /* 0x34 */ s32 heapWhere;
+    /* 0x38 */ s32 treeheapWhere;
     /* 0x3C */ CpuFunction* prev;
     /* 0x40 */ CpuFunction* left;
     /* 0x44 */ CpuFunction* right;
 }; // size = 0x48
 
-// cpu_treeRoot
 typedef struct CpuTreeRoot {
-    /* 0x00 */ uint16_t total;
-    /* 0x04 */ int32_t total_memory;
-    /* 0x08 */ int32_t root_address;
-    /* 0x0C */ int32_t start_range;
-    /* 0x10 */ int32_t end_range;
-    /* 0x14 */ int32_t cache_miss;
-    /* 0x18 */ int32_t cache[20];
+    /* 0x00 */ u16 total;
+    /* 0x04 */ s32 total_memory;
+    /* 0x08 */ s32 root_address;
+    /* 0x0C */ s32 start_range;
+    /* 0x10 */ s32 end_range;
+    /* 0x14 */ s32 cache_miss;
+    /* 0x18 */ s32 cache[20];
     /* 0x68 */ CpuFunction* left;
     /* 0x6C */ CpuFunction* right;
-    /* 0x70 */ int32_t kill_limit;
-    /* 0x74 */ int32_t kill_number;
-    /* 0x78 */ int32_t side;
+    /* 0x70 */ s32 kill_limit;
+    /* 0x74 */ s32 kill_number;
+    /* 0x78 */ s32 side;
     /* 0x7C */ CpuFunction* restore;
-    /* 0x80 */ int32_t restore_side;
+    /* 0x80 */ s32 restore_side;
 } CpuTreeRoot; // size = 0x84
 
-// _CPU_ADDRESS
 typedef struct CpuAddress {
-    /* 0x0 */ int32_t nN64;
-    /* 0x4 */ int32_t nHost;
+    /* 0x0 */ s32 nN64;
+    /* 0x4 */ s32 nHost;
     /* 0x8 */ CpuFunction* pFunction;
 } CpuAddress; // size = 0xC
 
 typedef struct CpuCodeHack {
-    /* 0x0 */ uint32_t nAddress;
-    /* 0x4 */ uint32_t nOpcodeOld;
-    /* 0x8 */ uint32_t nOpcodeNew;
+    /* 0x0 */ u32 nAddress;
+    /* 0x4 */ u32 nOpcodeOld;
+    /* 0x8 */ u32 nOpcodeNew;
 } CpuCodeHack; // size = 0xC
 
 // cpu_optimize
 typedef struct CpuOptimize {
-    /* 0x00 */ uint32_t validCheck;
-    /* 0x04 */ uint32_t destGPR_check;
-    /* 0x08 */ int32_t destGPR;
-    /* 0x0C */ int32_t destGPR_mapping;
-    /* 0x10 */ uint32_t destFPR_check;
-    /* 0x14 */ int32_t destFPR;
-    /* 0x18 */ uint32_t addr_check;
-    /* 0x1C */ int32_t addr_last;
-    /* 0x20 */ uint32_t checkType;
-    /* 0x24 */ uint32_t checkNext;
+    /* 0x00 */ u32 validCheck;
+    /* 0x04 */ u32 destGPR_check;
+    /* 0x08 */ s32 destGPR;
+    /* 0x0C */ s32 destGPR_mapping;
+    /* 0x10 */ u32 destFPR_check;
+    /* 0x14 */ s32 destFPR;
+    /* 0x18 */ u32 addr_check;
+    /* 0x1C */ s32 addr_last;
+    /* 0x20 */ u32 checkType;
+    /* 0x24 */ u32 checkNext;
 } CpuOptimize; // size = 0x28
 
 typedef struct Cpu Cpu;
-typedef int32_t (*CpuExecuteFunc)(Cpu* pCPU, int32_t nCount, int32_t nAddressN64, int32_t nAddressGCN);
+typedef s32 (*CpuExecuteFunc)(Cpu* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN);
 
 #if IS_OOT
 
 typedef struct Cpu {
-    /* 0x00000 */ int32_t nMode;
-    /* 0x00004 */ int32_t nTick;
-    /* 0x00008 */ int64_t nLo;
-    /* 0x00010 */ int64_t nHi;
-    /* 0x00018 */ int32_t nCountAddress;
-    /* 0x0001C */ int32_t iDeviceDefault;
-    /* 0x00020 */ uint32_t nPC;
-    /* 0x00024 */ uint32_t nWaitPC;
-    /* 0x00028 */ uint32_t nCallLast;
+    /* 0x00000 */ s32 nMode;
+    /* 0x00004 */ s32 nTick;
+    /* 0x00008 */ s64 nLo;
+    /* 0x00010 */ s64 nHi;
+    /* 0x00018 */ s32 nCountAddress;
+    /* 0x0001C */ s32 iDeviceDefault;
+    /* 0x00020 */ u32 nPC;
+    /* 0x00024 */ u32 nWaitPC;
+    /* 0x00028 */ u32 nCallLast;
     /* 0x0002C */ CpuFunction* pFunctionLast;
-    /* 0x00030 */ int32_t nReturnAddrLast;
-    /* 0x00034 */ int32_t survivalTimer;
-    /* 0x00038 */ uint32_t nTickLast;
-    /* 0x0003C */ uint32_t nRetrace;
-    /* 0x00040 */ uint32_t nRetraceUsed;
+    /* 0x00030 */ s32 nReturnAddrLast;
+    /* 0x00034 */ s32 survivalTimer;
+    /* 0x00038 */ u32 nTickLast;
+    /* 0x0003C */ u32 nRetrace;
+    /* 0x00040 */ u32 nRetraceUsed;
     /* 0x00048 */ CpuGpr aGPR[32];
     /* 0x00148 */ CpuFpr aFPR[32];
-    /* 0x00248 */ uint64_t aTLB[48][5];
-    /* 0x009C8 */ int32_t anFCR[32];
-    /* 0x00A48 */ int64_t anCP0[32];
+    /* 0x00248 */ u64 aTLB[48][5];
+    /* 0x009C8 */ s32 anFCR[32];
+    /* 0x00A48 */ s64 anCP0[32];
     /* 0x00B48 */ CpuExecuteFunc pfStep;
     /* 0x00B4C */ CpuExecuteFunc pfJump;
     /* 0x00B50 */ CpuExecuteFunc pfCall;
@@ -321,69 +294,69 @@ typedef struct Cpu {
     /* 0x00B58 */ CpuExecuteFunc pfRam;
     /* 0x00B5C */ CpuExecuteFunc pfRamF;
     /* 0x00B60 */ CpuDevice* apDevice[256];
-    /* 0x00F60 */ uint8_t aiDevice[1 << DEVICE_ADDRESS_INDEX_BITS];
+    /* 0x00F60 */ u8 aiDevice[1 << DEVICE_ADDRESS_INDEX_BITS];
     /* 0x10F60 */ void* gHeap1;
     /* 0x10F64 */ void* gHeap2;
-    /* 0x10F68 */ uint32_t aHeap1Flag[192];
-    /* 0x11268 */ uint32_t aHeap2Flag[13];
+    /* 0x10F68 */ u32 aHeap1Flag[192];
+    /* 0x11268 */ u32 aHeap2Flag[13];
     /* 0x1129C */ void* gHeapTree;
-    /* 0x112A0 */ uint32_t aHeapTreeFlag[125];
+    /* 0x112A0 */ u32 aHeapTreeFlag[125];
     /* 0x11494 */ CpuTreeRoot* gTree;
     /* 0x11498 */ CpuAddress aAddressCache[256];
-    /* 0x12098 */ int32_t nCountCodeHack;
+    /* 0x12098 */ s32 nCountCodeHack;
     /* 0x1209C */ CpuCodeHack aCodeHack[32];
-    /* 0x1221C */ uint32_t nFlagRAM;
-    /* 0x12220 */ uint32_t nFlagCODE;
-    /* 0x12224 */ uint32_t nCompileFlag;
-    /* 0x12228 */ int32_t unk_12228[18];
+    /* 0x1221C */ u32 nFlagRAM;
+    /* 0x12220 */ u32 nFlagCODE;
+    /* 0x12224 */ u32 nCompileFlag;
+    /* 0x12228 */ s32 unk_12228[18];
     /* 0x12270 */ CpuOptimize nOptimize;
-    /* 0x12298 */ int64_t nTimeRetrace;
-    /* 0x122A0 */ uint8_t pad[0x30];
+    /* 0x12298 */ s64 nTimeRetrace;
+    /* 0x122A0 */ u8 pad[0x30];
 } Cpu; // size = 0x122D0
 
 #elif IS_MM
 
 typedef struct Cpu {
-    /* 0x00000 */ int32_t nMode;
+    /* 0x00000 */ s32 nMode;
     /* 0x00004 */ char unk_0x04[0x14];
-    /* 0x00018 */ struct System* sys;
+    /* 0x00018 */ void* pHost;
     /* 0x0001C */ char unk_0x1C[0x4];
-    /* 0x00020 */ int64_t nLo;
-    /* 0x00028 */ int64_t nHi;
-    /* 0x00030 */ uint32_t nCountAddress;
-    /* 0x00034 */ uint8_t iDeviceDefault;
-    /* 0x00038 */ uint32_t nPC;
-    /* 0x0003C */ uint32_t nWaitPC;
+    /* 0x00020 */ s64 nLo;
+    /* 0x00028 */ s64 nHi;
+    /* 0x00030 */ u32 nCountAddress;
+    /* 0x00034 */ u8 iDeviceDefault;
+    /* 0x00038 */ u32 nPC;
+    /* 0x0003C */ u32 nWaitPC;
     /* 0x00040 */ char unk_0x3C[0xC];
     /* 0x0004C */ CpuFunction* pFunctionLast;
-    /* 0x00050 */ int32_t nReturnAddrLast;
-    /* 0x00054 */ int32_t survivalTimer;
+    /* 0x00050 */ s32 nReturnAddrLast;
+    /* 0x00054 */ s32 survivalTimer;
     /* 0x00058 */ CpuGpr aGPR[32];
     /* 0x00158 */ CpuFpr aFPR[32];
-    /* 0x00258 */ uint64_t aTLB[48][5];
-    /* 0x009D8 */ int32_t anFCR[32];
-    /* 0x00A58 */ int64_t anCP0[32];
+    /* 0x00258 */ u64 aTLB[48][5];
+    /* 0x009D8 */ s32 anFCR[32];
+    /* 0x00A58 */ s64 anCP0[32];
     /* 0x00B58 */ CpuExecuteFunc pfStep;
     /* 0x00B5C */ CpuExecuteFunc pfJump;
     /* 0x00B60 */ CpuExecuteFunc pfCall;
     /* 0x00B64 */ CpuExecuteFunc pfIdle;
     /* 0x00B68 */ CpuExecuteFunc pfRam;
     /* 0x00B6C */ CpuExecuteFunc pfRamF;
-    /* 0x00B70 */ int64_t nTimeLast;
+    /* 0x00B70 */ s64 nTimeLast;
     /* 0x00B78 */ char unk_0xB78[8];
     /* 0x00B80 */ CpuDevice* apDevice[256];
-    /* 0x00F80 */ uint8_t aiDevice[1 << DEVICE_ADDRESS_INDEX_BITS];
+    /* 0x00F80 */ u8 aiDevice[1 << DEVICE_ADDRESS_INDEX_BITS];
     /* 0x10F80 */ void* gHeap1;
     /* 0x10F84 */ void* gHeap2;
-    /* 0x10F88 */ uint32_t aHeap1Flag[256];
-    /* 0x11388 */ uint32_t aHeap2Flag[13];
+    /* 0x10F88 */ u32 aHeap1Flag[256];
+    /* 0x11388 */ u32 aHeap2Flag[13];
     /* 0x113BC */ CpuTreeRoot* gHeapTree;
     /* 0x113C0 */ char unk_0x113C0[0xDC0];
-    /* 0x12180 */ uint32_t known_regs;
+    /* 0x12180 */ u32 known_regs;
     /* 0x12184 */ char unk_0x12184[8];
-    /* 0x1218C */ uint32_t jr_is_ra;
+    /* 0x1218C */ u32 jr_is_ra;
     /* 0x12190 */ char unk_0x12190[0x18];
-    /* 0x121A8 */ uint32_t prev_loadstore_base;
+    /* 0x121A8 */ u32 prev_loadstore_base;
     /* 0x121AC */ char unk_0x121AC[0x14];
 } Cpu; // size = 0x121C0
 

--- a/include/hb_exception.h
+++ b/include/hb_exception.h
@@ -1,9 +1,25 @@
 #ifndef _HB_EXCEPTION_H
 #define _HB_EXCEPTION_H
 
+#include "os.h"
 #include "vc.h"
 
+enum ppc_exception {
+    EX_RESET,
+    EX_MACH_CHECK,
+    EX_DSI,
+    EX_ISI,
+    EX_EXT_INTR,
+    EX_ALIGN,
+    EX_PROG,
+    EX_FP_UNAVAIL,
+    EX_DECR,
+    EX_SYSCALL,
+    EX_TRACE,
+    EX_MAX
+};
+
 void init_hb_exceptions(void);
-void __handle_exception(enum ppc_exception exception);
+void __handle_exception(u8 type, OSContext* context);
 
 #endif

--- a/include/os.h
+++ b/include/os.h
@@ -1,0 +1,70 @@
+#ifndef _OS_H
+#define _OS_H
+
+#include "types.h"
+
+// os.h
+#define OS_CACHED_REGION_PREFIX 0x8000
+#define OS_BASE_CACHED          (OS_CACHED_REGION_PREFIX << 16)
+
+// OSAddress.h
+static inline void* OSPhysicalToCached(u32 ofs) {
+    return (void*)(ofs + OS_BASE_CACHED);
+}
+
+// OSContext.h
+typedef struct OSContext {
+    /* 0x0 */ u32 gprs[32];
+    /* 0x80 */ u32 cr;
+    /* 0x84 */ u32 lr;
+    /* 0x88 */ u32 ctr;
+    /* 0x8C */ u32 xer;
+    /* 0x90 */ f64 fprs[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqrs[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ f64 psfs[32];
+} OSContext;
+
+// OSThread.h
+typedef struct OSThreadQueue {
+    /* 0x0 */ struct OSThread* head;
+    /* 0x4 */ struct OSThread* tail;
+} OSThreadQueue;
+
+typedef struct OSMutexQueue {
+    /* 0x0 */ struct OSMutex* head;
+    /* 0x4 */ struct OSMutex* tail;
+} OSMutexQueue;
+
+typedef struct OSThread {
+    /* 0x000 */ OSContext context;
+    /* 0x2C8 */ u16 state;
+    /* 0x2CA */ u16 flags;
+    /* 0x2CC */ s32 suspend;
+    /* 0x2D0 */ s32 priority;
+    /* 0x2D4 */ s32 base;
+    /* 0x2D8 */ u32 val;
+    /* 0x2DC */ OSThreadQueue* queue;
+    /* 0x2E0 */ struct OSThread* next;
+    /* 0x2E4 */ struct OSThread* prev;
+    /* 0x2E8 */ OSThreadQueue joinQueue;
+    /* 0x2F0 */ struct OSMutex* mutex;
+    /* 0x2F4 */ OSMutexQueue mutexQueue;
+    /* 0x2FC */ struct OSThread* nextActive;
+    /* 0x300 */ struct OSThread* prevActive;
+    /* 0x304 */ u32* stackBegin;
+    /* 0x308 */ u32* stackEnd;
+    /* 0x30C */ s32 error;
+    /* 0x310 */ void* specific[2];
+} OSThread;
+
+typedef void* (*OSThreadFunc)(void* arg);
+typedef void (*OSExceptionHandler)(u8 type, OSContext* ctx);
+
+#endif

--- a/include/types.h
+++ b/include/types.h
@@ -1,0 +1,18 @@
+#ifndef _TYPES_H
+#define _TYPES_H
+
+#include <stdint.h>
+
+typedef int8_t s8;
+typedef uint8_t u8;
+typedef int16_t s16;
+typedef uint16_t u16;
+typedef int32_t s32;
+typedef uint32_t u32;
+typedef int64_t s64;
+typedef uint64_t u64;
+
+typedef float f32;
+typedef double f64;
+
+#endif

--- a/src/fat.c
+++ b/src/fat.c
@@ -1366,7 +1366,7 @@ void fat_root(fat_ctxt_t* fat, fat_file_t* file) {
 
 void fat_free(fat_path_t* fp) {
     list_destroy(&fp->entry_list);
-    xlHeapFree(&fp);
+    xlHeapFree((void**)&fp);
 }
 
 void fat_rewind(fat_file_t* file) {
@@ -1595,7 +1595,7 @@ int fat_create(fat_ctxt_t* fat, fat_entry_t* dir, const char* path, uint8_t attr
         memcpy(dir_path, dir_s, dir_len);
         dir_path[dir_len] = 0;
         int e = fat_find(fat, dir, dir_path, &dir_ent);
-        xlHeapFree(&dir_path);
+        xlHeapFree((void**)&dir_path);
         if (e) {
             return -1;
         }

--- a/src/homeboy.c
+++ b/src/homeboy.c
@@ -24,6 +24,21 @@ static _XL_OBJECTTYPE homeboy_class = {
     homeboy_event,
 };
 
+static inline u64 gettick() {
+    register u32 tbu;
+    register u32 tbl;
+
+    // clang-format off
+    __asm__ __volatile__(
+        "mftbl %0\n"
+        "mftbu %1\n"
+        ::
+        "r"(tbl), "r"(tbu));
+    // clang-format on
+
+    return (u64)((u64)tbu << 32 | tbl);
+}
+
 static void do_write() {
     homeboy_obj->ready = 0;
     homeboy_obj->busy = 1;

--- a/src/init.c
+++ b/src/init.c
@@ -16,12 +16,12 @@
 
 #define HB_HEAPSIZE 0xD000
 
-INIT bool _start(void** dest, size_t size) {
-    if (!ramSetSize(dest, 0x00800000)) {
+INIT bool _start(Ram* pRAM, s32 nSize) {
+    if (!ramSetSize(pRAM, 0x00800000)) {
         return 0;
     }
 
-    n64_dram = dest[1];
+    n64_dram = pRAM->pBuffer;
 
     init_hooks();
     homeboy_init();

--- a/src/list.c
+++ b/src/list.c
@@ -223,7 +223,7 @@ void list_erase(struct list* list, void* element) {
     if (header->next) {
         header->next->prev = header->prev;
     }
-    xlHeapFree(&header);
+    xlHeapFree((void**)&header);
     --list->size;
 }
 
@@ -234,7 +234,7 @@ void list_destroy(struct list* list) {
     }
     while (header) {
         struct list_element_header* next_header = header->next;
-        xlHeapFree(&header);
+        xlHeapFree((void**)&header);
         header = next_header;
     }
 }

--- a/src/sys.c
+++ b/src/sys.c
@@ -162,7 +162,7 @@ static void ent_stat(fat_entry_t* ent, struct stat* buf) {
 static void delete_desc(int file) {
     desc_t* desc = desc_list[file];
     fat_free(desc->fp);
-    xlHeapFree(&desc);
+    xlHeapFree((void**)&desc);
     desc_list[file] = NULL;
 }
 


### PR DESCRIPTION
I fixed a few signatures but not all, and moved OS structs to a new `os.h` since `cpu.h` will depend on it soon. But copy-pasting from decomp should be easier now with `s32` and friends