### PR TITLE
Define bool to be 4 bytes instead of using stdbool.h

### DIFF
--- a/include/fs.h
+++ b/include/fs.h
@@ -1,12 +1,12 @@
 #ifndef _FS_H
 #define _FS_H
 
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include "homeboy.h"
 #include "io.h"
+#include "types.h"
 
 #define FS_ERROR_EACCES        -1
 #define FS_ERROR_EEXIST        -2

--- a/include/sd.h
+++ b/include/sd.h
@@ -1,8 +1,9 @@
 #ifndef _SD_H
 #define _SD_H
 
-#include <stdbool.h>
 #include <stdint.h>
+
+#include "types.h"
 
 #define SDIO_HEAPSIZE                (0x5000)
 

--- a/include/types.h
+++ b/include/types.h
@@ -15,4 +15,10 @@ typedef uint64_t u64;
 typedef float f32;
 typedef double f64;
 
+// Ensure bool is 4 bytes to match decomp
+typedef int bool;
+
+#define true  1
+#define false 0
+
 #endif

--- a/include/vc.h
+++ b/include/vc.h
@@ -1,7 +1,6 @@
 #ifndef _VC_H
 #define _VC_H
 
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -1,4 +1,3 @@
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -6,6 +5,7 @@
 #include "cpu.h"
 #include "fs.h"
 #include "io.h"
+#include "types.h"
 #include "vc.h"
 
 typedef struct {

--- a/src/hb_debug.c
+++ b/src/hb_debug.c
@@ -4,6 +4,7 @@
 #include "hb_heap.h"
 #include "homeboy.h"
 #include "sys.h"
+#include "types.h"
 #include "vc.h"
 
 #ifdef HB_DBG

--- a/src/hb_fat.c
+++ b/src/hb_fat.c
@@ -5,6 +5,7 @@
 #include "hb_heap.h"
 #include "homeboy.h"
 #include "sys.h"
+#include "types.h"
 #include "vc.h"
 
 #if HB_FAT

--- a/src/hb_heap.c
+++ b/src/hb_heap.c
@@ -1,6 +1,5 @@
-#include <stdbool.h>
-
 #include "hb_heap.h"
+#include "types.h"
 
 class_hb_heap_t* hb_heap_obj = NULL;
 int hb_heap_event(void* heap_p, int event, void* arg);

--- a/src/hb_n64vcmem.c
+++ b/src/hb_n64vcmem.c
@@ -1,8 +1,8 @@
-#include <stdbool.h>
 #include <stddef.h>
 
 #include "hb_n64vcmem.h"
 #include "homeboy.h"
+#include "types.h"
 
 #if HB_N64VCMEM
 static void* hb_n64vcmem_dummy = NULL;

--- a/src/homeboy.c
+++ b/src/homeboy.c
@@ -1,4 +1,3 @@
-#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,6 +7,7 @@
 #include "fs.h"
 #include "homeboy.h"
 #include "sd.h"
+#include "types.h"
 #include "vc.h"
 
 int hb_hid = -1;

--- a/src/init.c
+++ b/src/init.c
@@ -1,4 +1,3 @@
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -12,6 +11,7 @@
 #include "homeboy.h"
 #include "hooks.h"
 #include "sys.h"
+#include "types.h"
 #include "vc.h"
 
 #define HB_HEAPSIZE 0xD000

--- a/src/sd.c
+++ b/src/sd.c
@@ -1,10 +1,10 @@
-#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 
 #include "homeboy.h"
 #include "io.h"
 #include "sd.h"
+#include "types.h"
 #include "vc.h"
 
 typedef struct {


### PR DESCRIPTION
Otherwise decomp struct offsets can be wrong if several bools are next to each other.