### PR TITLE
Patch frameSetDepth for gz

### DIFF
--- a/include/frame.h
+++ b/include/frame.h
@@ -1,0 +1,36 @@
+#ifndef _FRAME_H
+#define _FRAME_H
+
+#include "types.h"
+#include "version.h"
+
+#if IS_GC
+
+typedef struct Frame {
+    /* 0x00000 */ u8 pad1[0x124];
+    /* 0x00124 */ f32 rDepth;
+    /* 0x00128 */ f32 rDelta;
+    /* 0x0012C */ u8 pad2[0x3D024];
+} Frame; // size = 0x3D150
+
+#elif IS_WII && IS_OOT
+
+typedef struct Frame {
+    /* 0x00000 */ u8 pad1[0x148];
+    /* 0x00148 */ f32 rDepth;
+    /* 0x0014C */ f32 rDelta;
+    /* 0x00150 */ u8 pad2[0x3D000];
+} Frame; // size = 0x3D150
+
+#elif IS_WII && IS_MM
+
+typedef struct Frame {
+    /* 0x00000 */ u8 pad1[0x1DC];
+    /* 0x001DC */ f32 rDepth;
+    /* 0x001E0 */ f32 rDelta;
+    /* 0x001E4 */ u8 pad2[0x557D4];
+} Frame; // size = 0x559B8
+
+#endif
+
+#endif

--- a/lib/hb-D43J.txt
+++ b/lib/hb-D43J.txt
@@ -7,6 +7,7 @@ cpuSetDeviceGet                     = 0x800348FC;
 cpuSetDevicePut                     = 0x800348E4;
 cpuFindFunction                     = 0x80032BB8;
 ramSetSize                          = 0x8006C858;
+frameSetDepth_hook_addr             = 0x80070740;
 romLoadRange_hook_addr_1            = 0x8006E760;
 romLoadRange_hook_addr_2            = 0x8006E7CC;
 videoForceRetrace                   = 0x8008E120;

--- a/lib/hb-NACE.txt
+++ b/lib/hb-NACE.txt
@@ -6,6 +6,7 @@ cpuSetDeviceGet                     = 0x8003C7CC;
 cpuSetDevicePut                     = 0x8003C7E4;
 cpuFindFunction                     = 0x8003DC68;
 ramSetSize                          = 0x80041D98;
+frameSetDepth_hook_addr             = 0x8007E780;
 xlHeapTake                          = 0x80081104;
 xlHeapFree                          = 0x8008136C;
 xlObjectMake                        = 0x80082200;

--- a/lib/hb-NACJ.txt
+++ b/lib/hb-NACJ.txt
@@ -6,6 +6,7 @@ cpuSetDeviceGet                     = 0x8003C7B0;
 cpuSetDevicePut                     = 0x8003C7C8;
 cpuFindFunction                     = 0x8003DC4C;
 ramSetSize                          = 0x80041D7C;
+frameSetDepth_hook_addr             = 0x8007E774;
 xlHeapTake                          = 0x800810F8;
 xlHeapFree                          = 0x8008136C;
 xlObjectMake                        = 0x800821F4;

--- a/lib/hb-NARE.txt
+++ b/lib/hb-NARE.txt
@@ -6,6 +6,7 @@ cpuSetDeviceGet                     = 0x8004B608;
 cpuSetDevicePut                     = 0x8004B620;
 cpuFindFunction                     = 0x8004C930;
 ramSetSize                          = 0x800507C8;
+frameSetDepth_hook_addr             = 0x80053A2C;
 xlHeapTake                          = 0x80088790;
 xlHeapFree                          = 0x80088A10;
 xlObjectMake                        = 0x8008974C;

--- a/lib/hb-NARJ.txt
+++ b/lib/hb-NARJ.txt
@@ -6,6 +6,7 @@ cpuSetDeviceGet                     = 0x8004B67C;
 cpuSetDevicePut                     = 0x8004B694;
 cpuFindFunction                     = 0x8004C9A4;
 ramSetSize                          = 0x8005083C;
+frameSetDepth_hook_addr             = 0x80053AB0;
 xlHeapTake                          = 0x800887E0;
 xlHeapFree                          = 0x80088A60;
 xlObjectMake                        = 0x8008979C;


### PR DESCRIPTION
The implementation of gDPSetPrimDepth is broken for depths other than 0. AFAIK this doesn't affect anything in-game, but fixing it will help gz clear the Z buffer for the scene explorer (which is currently broken on VC).