### PR TITLE
Fix `gnFlagZelda` not set properly

### DIFF
--- a/include/vc.h
+++ b/include/vc.h
@@ -148,6 +148,7 @@ typedef struct Ram {
 } Ram; // size = 0x48
 
 #define SYSTEM_CPU(pSystem) ((void*)(((System*)(pSystem))->apObject[SOT_CPU]))
+#define SYSTEM_ROM(pSystem) ((Rom*)(((System*)(pSystem))->apObject[SOT_ROM]))
 
 // xlObject.h
 typedef struct _XL_OBJECTTYPE _XL_OBJECTTYPE;
@@ -188,6 +189,7 @@ u32 OSGetTick(void);
 
 extern s32 ganMapGPR[32];
 extern System* gpSystem;
+extern u32 gnFlagZelda;
 
 // TODO: use decomp types and names
 #define cur_thread  (*(volatile OSThread**)0x800000C0)

--- a/lib/hb-D43J.txt
+++ b/lib/hb-D43J.txt
@@ -24,3 +24,4 @@ OSGetTime                           = 0x800A14E0;
 OSGetTick                           = 0x800A14F8;
 ganMapGPR                           = 0x800ED338;
 gpSystem                            = 0x8018B894;
+gnFlagZelda                         = 0x8018B968;

--- a/src/init.c
+++ b/src/init.c
@@ -18,7 +18,7 @@
 #define HB_HEAPSIZE 0xD000
 
 /**
- * @brief Fix `gnFlagZelda` not being set properly.
+ * @brief Fix `gnFlagZelda` not being set properly on GameCube versions.
  *
  * It checks the rom's filename and set the flag to 1 if it's an MQ rom, otherwise the value used will be 2.
  * The emulator checks the bits of the flag's value, if the bit 2 is set (from `gnFlagZelda & 2`), it will use non-MQ
@@ -30,7 +30,7 @@ static void patch_gnFlagZelda(void) {
 
     // MQ roms are named "urazlj_f.n64", checking the first 3 characters will tell if the game used is MQ or not.
     if (pROM->acNameFile[0] == 'u' && pROM->acNameFile[1] == 'r' && pROM->acNameFile[2] == 'a') {
-        gnFlagZelda = 1;
+        gnFlagZelda = 0;
     } else {
         gnFlagZelda = 2;
     }

--- a/src/init.c
+++ b/src/init.c
@@ -19,9 +19,10 @@
 
 /**
  * @brief Fix `gnFlagZelda` not being set properly.
- * 
+ *
  * It checks the rom's filename and set the flag to 1 if it's an MQ rom, otherwise the value used will be 2.
- * The emulator checks the bits of the flag's value, if the bit 2 is set (from `gnFlagZelda & 2`), it will use non-MQ mode.
+ * The emulator checks the bits of the flag's value, if the bit 2 is set (from `gnFlagZelda & 2`), it will use non-MQ
+ * mode.
  */
 static void patch_gnFlagZelda(void) {
 #if IS_GC


### PR DESCRIPTION
Since the rom is modified (because of gz), the emulator can't tell which type of game we are running. To fix this issue, we're reading the rom's first three characters of the filename (either `urazlj_f.n64` or `zlj_f.n64`) and set the flag to 1 if it's MQ, and 2 if it's the vanilla game. The emulator will use `gnFlagZelda & 2` to determine if it's the vanilla game or MQ.

To test this PR you need to checkout this branch in your local gz clone, build the thing and run the game on a real console as Dolphin can't display the loading background properly.

Also I put it in its own function, not sure what's the best thing to do if we want to optimize the file's size but I wanted to document what I did.